### PR TITLE
Fixes for providers without roles and quicksight

### DIFF
--- a/aws/data_source_aws_caller_identity.go
+++ b/aws/data_source_aws_caller_identity.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAwsCallerIdentity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCallerIdentityRead,
+
+		Schema: map[string]*schema.Schema{
+			"account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).stsconn
+
+	log.Printf("[DEBUG] Reading Caller Identity")
+	res, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+
+	if err != nil {
+		return fmt.Errorf("Error getting Caller Identity: %v", err)
+	}
+
+	log.Printf("[DEBUG] Received Caller Identity: %s", res)
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("account_id", res.Account)
+	d.Set("arn", res.Arn)
+	d.Set("user_id", res.UserId)
+
+	return nil
+}

--- a/aws/provider.go
+++ b/aws/provider.go
@@ -155,7 +155,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
-		DataSourcesMap: map[string]*schema.Resource{},
+		DataSourcesMap: map[string]*schema.Resource{
+			"aws_caller_identity": dataSourceAwsCallerIdentity(),
+		},
 
 		ResourcesMap: map[string]*schema.Resource{
 			"aws_transfer_server":                     resourceAwsTransferServer(),

--- a/aws/resource_aws_quicksight_data_source.go
+++ b/aws/resource_aws_quicksight_data_source.go
@@ -443,7 +443,7 @@ func resourceAwsQuickSightDataSource() *schema.Resource {
 					quicksight.DataSourceTypeJira,
 					quicksight.DataSourceTypeAwsIotAnalytics,
 				}, false),
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 		},

--- a/go.sum
+++ b/go.sum
@@ -337,6 +337,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.7.0/go.mod h1:OjgQmey5VxnPej/buEhe+
 github.com/hashicorp/terraform-plugin-sdk v1.8.0 h1:HE1p52nzcgz88hIJmapUnkmM9noEjV3QhTOLaua5XUA=
 github.com/hashicorp/terraform-plugin-sdk v1.8.0/go.mod h1:OjgQmey5VxnPej/buEhe+YqKm0KNvV3QqU4hkqHqPCY=
 github.com/hashicorp/terraform-plugin-sdk v1.15.0 h1:bmYnTT7MqNXlUHDc7pT8E6uKT2g/upjlRLypJFK1OQU=
+github.com/hashicorp/terraform-plugin-sdk v1.16.0 h1:NrkXMRjHErUPPTHQkZ6JIn6bByiJzGnlJzH1rVdNEuE=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.1 h1:qG6EdnW2UrftQI4mBdIsWP4YWqYJXynZtl0shQYuU78=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.1/go.mod h1:BRz6UtYmksQJU0eMfahQR8fcJf8tIe77gn7YVm6rGD4=
 github.com/hashicorp/terraform-plugin-test v1.2.0 h1:AWFdqyfnOj04sxTdaAF57QqvW7XXrT8PseUHkbKsE8I=


### PR DESCRIPTION
This contains 2 fixes:

1. Allows the `candidaws` provider to be used without roles (just credentials or profiles) so that we don't see this error:

```
2020-09-28T15:01:35.141-0400 [DEBUG] plugin.terraform-provider-candidaws_v1.1.2: panic: runtime error: invalid memory address or nil pointer dereference
```

2. Fixes a `aws_quicksight_data_source` error:

```
Error: Internal validation of the provider failed! This is always a bug
with the provider itself, and not a user issue. Please report
this bug:
1 error occurred:
	* resource aws_quicksight_data_source: data_source_type: Default cannot be set with Required
```

I have tested this with the following Terraform:

```
provider candidaws {
  region = "us-gov-west-1"
  profile = "exampleprofile"
}

data "aws_caller_identity" "whoami" {
    provider = candidaws
}

output "identity" {
    value = data.aws_caller_identity.whoami.account_id
}
```

After a `terraform apply` the `terraform output` command reveals:

```
> terraform output
identity = ###########
```