### PR TITLE
Hotfix Organization Expired Handshake 

### DIFF
--- a/aws/resource_aws_organizations_invitation.go
+++ b/aws/resource_aws_organizations_invitation.go
@@ -57,40 +57,16 @@ func resourceAwsOrganizationsInvitationCreate(d *schema.ResourceData, meta inter
 
 func resourceAwsOrganizationsInvitationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).organizationsconn
-
-	describeOpts := &organizations.DescribeAccountInput{
-		AccountId: aws.String(d.Get("account_id").(string)),
-	}
-	describeResp, describeErr := conn.DescribeAccount(describeOpts)
-
-	if describeErr != nil {
-		return fmt.Errorf("error describing account (%s): %s", d.Get("account_id").(string), describeErr)
-	}
-
-	account := describeResp.Account
-
-	if *account.Status == "ACTIVE" {
-		return nil
-	}
-
 	params := &organizations.DescribeHandshakeInput{
 		HandshakeId: aws.String(d.Id()),
 	}
 	resp, err := conn.DescribeHandshake(params)
-
 	if err != nil {
-		return fmt.Errorf("error describing handshake (%s): %s", d.Id(), err)
-	}
-
-	handshake := resp.Handshake
-	if handshake == nil {
-		log.Printf("[WARN] Handshake does not exist, removing from state: %s", d.Id())
-		d.SetId("")
+		log.Printf("[WARN] Handshake no longer exist")
 		return nil
 	}
-
+	handshake := resp.Handshake
 	d.Set("arn", handshake.Arn)
-
 	return nil
 }
 


### PR DESCRIPTION
Problem: 
Regarding resource _resource_aws_organizations_invitation_ 30 days after an invite was sent to an account to join an Org the handshake will be deleted.  Terraform will return an error "error describing handshake" and the pipeline will fail to plan.  A solution was attempted in v1.1.6-1.1.7 and it solved the problem by describing the given account and checking if its Status was ACTIVE in the org.  But v1.1.7 failed because if an account is not in the org Terraform will throw the following error: 
```
_* AccountNotFoundException
We can't find an AWS account with the AccountId that you specified, or the
account whose credentials you used to make this request isn't a member of
an organization._
```

Solution: 
Removed the logic to describe the account, and simply return nil if the handshake does not exist.  When tested on accounts with expired handshakes Terraform plan was successful without any changes to the resources. 
